### PR TITLE
custom logos

### DIFF
--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -90,13 +90,13 @@
 % frame layout
 % ---------------------------------------------
 % [options for includegraphics]{logoname}
-\newcommand*\intitutelogo[2][]{\def\@institutelogo{\includegraphics[height=4.5ex,#1]{#2}}}
-\newcommand*\clearintitutelogo{\def\@institutelogo{}}
+\newcommand*\institutelogo[2][]{\def\@institutelogo{\includegraphics[height=4.5ex,#1]{#2}}}
+\newcommand*\clearinstitutelogo{\def\@institutelogo{}}
 \newcommand*\universitylogo[2][]{\def\@universitylogo{\includegraphics[height=4.5ex,#1]{#2}}}
 \newcommand*\clearuniversitylogo{\def\@universitylogo{}}
 % default for the university, after all, it is the layout of uulm
 \universitylogo{uulm}
-\clearintitutelogo
+\clearinstitutelogo
 
 \renewcommandx{\maketitle}[2][1=apr21-o25a,2=150]{
     {

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -94,7 +94,7 @@
 \newcommand*\clearinstitutelogo{\def\@institutelogo{}}
 \newcommand*\universitylogo[2][]{\def\@universitylogo{\includegraphics[height=4.5ex,#1]{#2}}}
 \newcommand*\clearuniversitylogo{\def\@universitylogo{}}
-\def\@mainlogo{\@institutelogo\hfill\@universitylogo}
+\def\@mainlogo{\@institutelogo\hskip0pt plus 1filll\relax\@universitylogo}
 \newif\ifuulm@logos@first@
 \newcommand*\uulmlogos[2][]{\def\@mainlogo{%
     \uulm@logos@first@true

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -94,6 +94,17 @@
 \newcommand*\clearinstitutelogo{\def\@institutelogo{}}
 \newcommand*\universitylogo[2][]{\def\@universitylogo{\includegraphics[height=4.5ex,#1]{#2}}}
 \newcommand*\clearuniversitylogo{\def\@universitylogo{}}
+\def\@mainlogo{\@institutelogo\hfill\@universitylogo}
+\newif\ifuulm@logos@first@
+\newcommand*\uulmlogos[2][]{\def\@mainlogo{%
+    \uulm@logos@first@true
+    \@for\@image:={#2}\do{%
+        \ifuulm@logos@first@\uulm@logos@first@false\else \hskip0pt plus 1filll\fi
+        \ifthenelse{\equal{\@image}{}}{}{%
+            \includegraphics[height=4.5ex,#1]{\@image}%
+        }%
+    }%
+}}
 % default for the university, after all, it is the layout of uulm
 \universitylogo{uulm}
 \clearinstitutelogo
@@ -114,14 +125,11 @@
             \ifx \insertdate \empty \else $\vert$ \insertdate \fi
             \hspace*{20pt}
         \end{beamercolorbox}%
-        \nointerlineskip%
+        \nointerlineskip
         \begin{beamercolorbox}[wd=\paperwidth,ht=4.5ex,dp=2ex,left]{logobox}
-            \centering
-            \vspace{-1ex}
+            \vspace{-1ex}%
             \hspace{10pt}
-            \@institutelogo
-            \hfill
-            \@universitylogo
+            \@mainlogo
             \hspace{10pt}
         \end{beamercolorbox}%
     \end{frame}

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -89,6 +89,15 @@
 % ---------------------------------------------
 % frame layout
 % ---------------------------------------------
+% [options for includegraphics]{logoname}
+\newcommand*\intitutelogo[2][height=4.5ex]{\def\@institutelogo{\includegraphics[#1]{#2}}}
+\newcommand*\clearintitutelogo{\def\@institutelogo{}}
+\newcommand*\universitylogo[2][height=4.5ex]{\def\@universitylogo{\includegraphics[#1]{#2}}}
+\newcommand*\clearuniversitylogo{\def\@universitylogo{}}
+% default for the university, after all, it is the layout of uulm
+\universitylogo{uulm}
+\clearintitutelogo
+
 \renewcommandx{\maketitle}[2][1=apr21-o25a,2=150]{
     {
     \usebackgroundtemplate{\includegraphics[trim=0 0 0 #2,clip,width=\paperwidth]{#1}}
@@ -99,7 +108,7 @@
         \end{beamercolorbox}%
         \nointerlineskip%
         \begin{beamercolorbox}[wd=\paperwidth,ht=2.25ex,dp=1ex,right]{subtitlebox}
-            \small 
+            \small
             \ifx \insertsubtitle \empty \else \insertsubtitle\ $\vert$ \fi
             \insertauthor\
             \ifx \insertdate \empty \else $\vert$ \insertdate \fi
@@ -110,13 +119,13 @@
             \centering
             \vspace{-1ex}
             \hspace{10pt}
-            \includegraphics[height=4.5ex]{sp} % SPECIFY INSTITUTE LOGO HERE
+            \@institutelogo
             \hfill
-            \includegraphics[height=4.5ex]{uulm}
+            \@universitylogo
             \hspace{10pt}
         \end{beamercolorbox}%
     \end{frame}
-    }  
+    }
 }
 
 \setbeamertemplate{frametitle}{
@@ -133,9 +142,9 @@
             \insertshortauthor
             \hfill
             \insertshorttitle\
-            \ifx \insertsubtitle \empty \else {-- \insertshortsubtitle} \fi 
-            \ifx \insertsectionhead \empty \else {-- \thesection.~\insertsectionhead} \fi 
-            \hspace{0.03\textwidth} 
+            \ifx \insertsubtitle \empty \else {-- \insertshortsubtitle} \fi
+            \ifx \insertsectionhead \empty \else {-- \thesection.~\insertsectionhead} \fi
+            \hspace{0.03\textwidth}
         \end{beamercolorbox}%
         \begin{beamercolorbox}[wd=0.07\textwidth,ht=3mm,dp=1.5mm,center]{mypagenumber}
             \insertframenumber

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -90,9 +90,9 @@
 % frame layout
 % ---------------------------------------------
 % [options for includegraphics]{logoname}
-\newcommand*\intitutelogo[2][height=4.5ex]{\def\@institutelogo{\includegraphics[#1]{#2}}}
+\newcommand*\intitutelogo[2][]{\def\@institutelogo{\includegraphics[height=4.5ex,#1]{#2}}}
 \newcommand*\clearintitutelogo{\def\@institutelogo{}}
-\newcommand*\universitylogo[2][height=4.5ex]{\def\@universitylogo{\includegraphics[#1]{#2}}}
+\newcommand*\universitylogo[2][]{\def\@universitylogo{\includegraphics[height=4.5ex,#1]{#2}}}
 \newcommand*\clearuniversitylogo{\def\@universitylogo{}}
 % default for the university, after all, it is the layout of uulm
 \universitylogo{uulm}

--- a/demo-slides/demoSlides.tex
+++ b/demo-slides/demoSlides.tex
@@ -7,6 +7,12 @@
 \usepackage{../beamerthemeuulm} % use the inofficial uulm beamer theme
 \setfaculty{infIngPsy} % set the color scheme for your faculty here [med/infIngPsy/math/nat]
 
+%\intitutelogo{sp} % set the institute logo
+%\universitylogo{uulm} % set a new university logo
+% use these commands, to clear existing logos
+%\clearuniversitylogo
+%\clearintitutelogo
+
 %\usepackage[ngerman]{babel} % use this line for slides in German
 %\recordingtrue % special recording mode for use with a greenscreen, gives you space to show yourself in a layer in front of the slides, has no effect in the handout mode
 
@@ -107,7 +113,7 @@
 \subsection{Left, Middle, and Right}
 \begin{frame}{\insertsubsection}
     \leftmiddleandright{
-        This is an example text that is shown in the \textbf{left column}. 
+        This is an example text that is shown in the \textbf{left column}.
     }{
         This is an example text that is shown in the \textbf{middle column}.
     }{
@@ -202,9 +208,9 @@
 	\vfill
 	\mynote{Explanation}{
 		In \textbf{handout mode}, both columns are visible.
-	
+
 		In \textbf{slide mode}, only the left column is shown at the beginning and then both columns (cf. \textbf{Left then Right}).
-		
+
 		In \textbf{recording mode}, only the left column is shown at the beginning, then an empty slide (to walk to the other side), and finally only the right column.
 	}
 \end{frame}
@@ -218,9 +224,9 @@
 	\vfill
 	\mynote{Explanation}{
 		In \textbf{handout mode}, both columns are visible.
-	
+
 		In \textbf{slide mode}, only the right column is shown at the beginning and then both columns (cf. \textbf{Right then Left}).
-		
+
 		In \textbf{recording mode}, only the right column is shown at the beginning, then an empty slide (to walk to the other side), and finally only the left column.
 	}
 \end{frame}
@@ -237,9 +243,9 @@
 	\vfill
 	\mynote{Explanation}{
 		In \textbf{handout mode}, all columns are visible.
-	
+
 		In \textbf{slide mode}, only the left column is shown at the beginning, then additionally the middle column, and finally all columns (cf. \textbf{Left, Middle, then Right}).
-		
+
 		In \textbf{recording mode}, only the left column is shown at the beginning, then only the middle column, and finally only the right column (again interleaved with empty slides).
 	}
 \end{frame}
@@ -255,9 +261,9 @@
 	\vfill
 	\mynote{Explanation}{
 		In \textbf{handout mode}, all columns are visible.
-	
+
 		In \textbf{slide mode}, only the right column is shown at the beginning, then additionally the middle column, and finally all columns (cf. \textbf{Right, Middle, then Left}).
-		
+
 		In \textbf{recording mode}, only the right column is shown at the beginning, then only the middle column, and finally only the left column (again interleaved with empty slides).
 	}
 \end{frame}
@@ -268,9 +274,9 @@
 \begin{frame}{\insertsubsection\ -- Long Titles are Scaled Down to the Available Space}
 	\mynote{Explanation}{
 		Very long frame titles are scaled down automatically.
-		
+
 		This can avoid annoying linebreaks for a single character or word.
-		
+
 		Use with care.
 	}
 \end{frame}

--- a/demo-slides/demoSlides.tex
+++ b/demo-slides/demoSlides.tex
@@ -12,6 +12,7 @@
 % use these commands, to clear existing logos
 %\clearuniversitylogo
 %\clearinstitutelogo
+\uulmlogos{sp,sp,uulm}
 
 %\usepackage[ngerman]{babel} % use this line for slides in German
 %\recordingtrue % special recording mode for use with a greenscreen, gives you space to show yourself in a layer in front of the slides, has no effect in the handout mode

--- a/demo-slides/demoSlides.tex
+++ b/demo-slides/demoSlides.tex
@@ -7,11 +7,11 @@
 \usepackage{../beamerthemeuulm} % use the inofficial uulm beamer theme
 \setfaculty{infIngPsy} % set the color scheme for your faculty here [med/infIngPsy/math/nat]
 
-%\intitutelogo{sp} % set the institute logo
+%\institutelogo{sp} % set the institute logo
 %\universitylogo{uulm} % set a new university logo
 % use these commands, to clear existing logos
 %\clearuniversitylogo
-%\clearintitutelogo
+%\clearinstitutelogo
 
 %\usepackage[ngerman]{babel} % use this line for slides in German
 %\recordingtrue % special recording mode for use with a greenscreen, gives you space to show yourself in a layer in front of the slides, has no effect in the handout mode

--- a/demo-slides/demoSlides.tex
+++ b/demo-slides/demoSlides.tex
@@ -12,7 +12,9 @@
 % use these commands, to clear existing logos
 %\clearuniversitylogo
 %\clearinstitutelogo
-\uulmlogos{sp,sp,uulm}
+% allows to freely configure multiple logos,
+% this overwrites any setting done be \institutelogo, \universitylogo, ...
+% \uulmlogos{sp,uulm}
 
 %\usepackage[ngerman]{babel} % use this line for slides in German
 %\recordingtrue % special recording mode for use with a greenscreen, gives you space to show yourself in a layer in front of the slides, has no effect in the handout mode


### PR DESCRIPTION
Two new commands to set the logo[^1]:

```latex
\institutelogo[<includegraphics>]{<filename>}
\universitylogo[<includegraphics>]{<filename>}
```

Furthermore, two additional commands to remove the logo:

```latex
\clearinstitutelogo
\clearuniversitylogo
```

The default is:

```latex
\universitylogo{uulm}
\clearinstitutelogo
```

Including the sp-logo is easy with just: `\institutelogo{sp}` (i added lines to the demoSlides which are commented-out).


If someone adds a custom image it will be scaled to the same height. It is up to the user to ensure, that the scaled image remains readable and of a reasonable width (we could constraint that, or add some clippings, but at least in my opinion, that would only unnecessary complicate the code). 



[^1]: With `<includegraphics>`, I refer to additional options accepted by the `\includegraphics`-command (e.g. `width=.5\linewidth, keepaspectratio`). 