### PR TITLE
fix: resolve problem with empty colorbox titles

### DIFF
--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -291,37 +291,37 @@
 % color boxes
 % ---------------------------------------------
 \newcommand{\mydefinition}[2]{
-	\begin{tcolorbox}[title={\setlength{\parskip}{0ex}\vphantom{/}#1},colback=orange!10,colframe=orange!30,coltitle=black,fonttitle=\bfseries,left=1mm,right=1mm,top=1mm,bottom=1mm]
+	\begin{tcolorbox}[title={#1},before title={\setlength{\parskip}{0ex}\vphantom{/}},colback=orange!10,colframe=orange!30,coltitle=black,fonttitle=\bfseries,left=1mm,right=1mm,top=1mm,bottom=1mm]
 		#2
 	\end{tcolorbox}
 }
 
 \newcommand{\mydefinitiontight}[2]{
-	\begin{tcolorbox}[title={\setlength{\parskip}{0ex}\vphantom{/}#1},colback=white,colframe=orange!30,coltitle=black,fonttitle=\bfseries,left=0mm,right=0mm,top=0mm,bottom=0mm]
+	\begin{tcolorbox}[title={#1},before title={\setlength{\parskip}{0ex}\vphantom{/}},colback=white,colframe=orange!30,coltitle=black,fonttitle=\bfseries,left=0mm,right=0mm,top=0mm,bottom=0mm]
 		#2
 	\end{tcolorbox}
 }
 
 \newcommand{\myexample}[2]{
-	\begin{tcolorbox}[title={\setlength{\parskip}{0ex}\vphantom{/}#1},colback=blue!10,colframe=blue!30,coltitle=black,fonttitle=\bfseries,left=1mm,right=1mm,top=1mm,bottom=1mm]
+	\begin{tcolorbox}[title={#1},before title={\setlength{\parskip}{0ex}\vphantom{/}},colback=blue!10,colframe=blue!30,coltitle=black,fonttitle=\bfseries,left=1mm,right=1mm,top=1mm,bottom=1mm]
 		#2
 	\end{tcolorbox}
 }
 
 \newcommand{\myexampletight}[2]{
-	\begin{tcolorbox}[title={\setlength{\parskip}{0ex}\vphantom{/}#1},colback=white,colframe=blue!30,coltitle=black,fonttitle=\bfseries,left=0mm,right=0mm,top=0mm,bottom=0mm]
+	\begin{tcolorbox}[title={#1},before title={\setlength{\parskip}{0ex}\vphantom{/}},colback=white,colframe=blue!30,coltitle=black,fonttitle=\bfseries,left=0mm,right=0mm,top=0mm,bottom=0mm]
 		#2
 	\end{tcolorbox}
 }
 
 \newcommand{\mynote}[2]{
-	\begin{tcolorbox}[title={\setlength{\parskip}{0ex}\vphantom{/}#1},colback=red!10,colframe=red!30,coltitle=black,fonttitle=\bfseries,left=1mm,right=1mm,top=1mm,bottom=1mm]
+	\begin{tcolorbox}[title={#1},before title={\setlength{\parskip}{0ex}\vphantom{/}},colback=red!10,colframe=red!30,coltitle=black,fonttitle=\bfseries,left=1mm,right=1mm,top=1mm,bottom=1mm]
 		#2
 	\end{tcolorbox}
 }
 
 \newcommand{\mynotetight}[2]{
-	\begin{tcolorbox}[title={\setlength{\parskip}{0ex}\vphantom{/}#1},colback=white,colframe=red!30,coltitle=black,fonttitle=\bfseries,left=0mm,right=0mm,top=0mm,bottom=0mm]
+	\begin{tcolorbox}[title={#1},before title={\setlength{\parskip}{0ex}\vphantom{/}},colback=white,colframe=red!30,coltitle=black,fonttitle=\bfseries,left=0mm,right=0mm,top=0mm,bottom=0mm]
 		#2
 	\end{tcolorbox}
 }


### PR DESCRIPTION
I applied the fix from @EagleoutIce so now empty titles in colorboxes don't result in an empty title bar anymore.