### PR TITLE
feat: add includeonlyframes example to demo slides

### DIFF
--- a/demo-slides/demoSlides.tex
+++ b/demo-slides/demoSlides.tex
@@ -12,6 +12,7 @@
 %\usepackage[ngerman]{babel} % use this line for slides in German
 %\recordingtrue % special recording mode for use with a greenscreen, gives you space to show yourself in a layer in front of the slides, has no effect in the handout mode
 
+%\includeonlyframes{current} % default mechanism of beamer to include only labeled frames, can be used for debugging or drafting
 
 \title[Short Title]{This is the Long Title} % short title is used for the slide footer but optional
 \subtitle[Short Subtitle]{This is the Long Subtitle} % subtitles are optional at all
@@ -35,7 +36,7 @@
 \section{Lists and Boxes}
 
 \subsection{Lists and Numbered Lists}
-\begin{frame}{\insertsubsection}
+\begin{frame}[label=current]{\insertsubsection}
 	\leftandright{
 	    Lists can be nested to a depth of three:
 	    \begin{itemize}


### PR DESCRIPTION
I added an example for the use of `\includeonlyframes{}`.