### PR TITLE
feat: add \againtitle macro to repeat last title slide

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The title picture can be changed with an optional parameter: ``\maketitle[<path-
 
 If no picture is given (`\maketitle`), a default picture is used. To create a title frame without a picture, you can use `\maketitle[]`.
 
+To repeat the title slide you can use the command `\againtitle` at any point. It creates a copy of the last title slide with the same picture and picture-offset.
+
 ### Section Frames
 
 At the begin of each section a title slide is automatically generated. If you are in handout-mode, this slide also includes an overview of all sections and subsections that can be used to navigate through the slides easily.

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -151,8 +151,8 @@
 }
 
 \renewcommandx{\maketitle}[2][1=apr21-o25a,2=150]{
-    \def \uulmtitlepicture {#1}
-    \def \uulmtitlepictureoffset {#2}
+    \gdef\uulmtitlepicture{#1}
+    \gdef\uulmtitlepictureoffset{#2}
     \createtitleslide{\uulmtitlepicture}{\uulmtitlepictureoffset}
 }
 

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -123,7 +123,7 @@
 \universitylogo{uulm}
 \clearinstitutelogo
 
-\newcommand{\createtitleslide}{
+\newcommand{\@createtitleslide}{
     {
     \ifx \uulmtitlepicture \empty \else \usebackgroundtemplate{\includegraphics[trim=0 0 0 \uulmtitlepictureoffset,clip,width=\paperwidth]{\uulmtitlepicture}} \fi
     \begin{frame}[plain]
@@ -153,12 +153,12 @@
 \renewcommandx{\maketitle}[2][1=apr21-o25a,2=150]{
     \gdef\uulmtitlepicture{#1}
     \gdef\uulmtitlepictureoffset{#2}
-    \createtitleslide
+    \@createtitleslide
 }
 
 \newcommand{\againtitle}{
     \ifcsname uulmtitlepicture\endcsname
-        \createtitleslide
+        \@createtitleslide
     \else
         \PackageError{beamerthemeuulm}{To use \string\againtitle\space you must first use \string\maketitle!}{Either comment out this line or check if you forgot to issue the \string\maketitle-macro.}%
     \fi

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -157,7 +157,11 @@
 }
 
 \newcommand{\againtitle}{
-    \createtitleslide
+    \ifcsname uulmtitlepicture\endcsname
+        \createtitleslide
+    \else
+        \PackageError{beamerthemeuulm}{To use \string\againtitle\space you must first use \string\maketitle!}{Either comment out this line or check if you forgot to issue the \string\maketitle-macro.}%
+    \fi
 }
 
 \setbeamertemplate{frametitle}{

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -123,9 +123,9 @@
 \universitylogo{uulm}
 \clearinstitutelogo
 
-\newcommand{\createtitleslide}[2]{
+\newcommand{\createtitleslide}{
     {
-    \ifx \uulmtitlepicture \empty \else \usebackgroundtemplate{\includegraphics[trim=0 0 0 #2,clip,width=\paperwidth]{#1}} \fi
+    \ifx \uulmtitlepicture \empty \else \usebackgroundtemplate{\includegraphics[trim=0 0 0 \uulmtitlepictureoffset,clip,width=\paperwidth]{\uulmtitlepicture}} \fi
     \begin{frame}[plain]
         \vskip0pt plus 1filll
         \begin{beamercolorbox}[wd=\paperwidth,ht=4.5ex,dp=2ex,right]{titlebox}
@@ -153,11 +153,11 @@
 \renewcommandx{\maketitle}[2][1=apr21-o25a,2=150]{
     \gdef\uulmtitlepicture{#1}
     \gdef\uulmtitlepictureoffset{#2}
-    \createtitleslide{\uulmtitlepicture}{\uulmtitlepictureoffset}
+    \createtitleslide
 }
 
 \newcommand{\againtitle}{
-    \createtitleslide{\uulmtitlepicture}{\uulmtitlepictureoffset}
+    \createtitleslide
 }
 
 \setbeamertemplate{frametitle}{

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -123,10 +123,9 @@
 \universitylogo{uulm}
 \clearinstitutelogo
 
-\renewcommandx{\maketitle}[2][1=apr21-o25a,2=150]{
+\newcommand{\createtitleslide}[2]{
     {
-    \def \picture {#1}
-    \ifx \picture \empty \else \usebackgroundtemplate{\includegraphics[trim=0 0 0 #2,clip,width=\paperwidth]{#1}} \fi
+    \ifx \uulmtitlepicture \empty \else \usebackgroundtemplate{\includegraphics[trim=0 0 0 #2,clip,width=\paperwidth]{#1}} \fi
     \begin{frame}[plain]
         \vskip0pt plus 1filll
         \begin{beamercolorbox}[wd=\paperwidth,ht=4.5ex,dp=2ex,right]{titlebox}
@@ -149,6 +148,16 @@
         \end{beamercolorbox}%
     \end{frame}
     }
+}
+
+\renewcommandx{\maketitle}[2][1=apr21-o25a,2=150]{
+    \def \uulmtitlepicture {#1}
+    \def \uulmtitlepictureoffset {#2}
+    \createtitleslide{\uulmtitlepicture}{\uulmtitlepictureoffset}
+}
+
+\newcommand{\againtitle}{
+    \createtitleslide{\uulmtitlepicture}{\uulmtitlepictureoffset}
 }
 
 \setbeamertemplate{frametitle}{

--- a/demo-slides/demoSlides.tex
+++ b/demo-slides/demoSlides.tex
@@ -250,6 +250,9 @@
 	\vfill
 \end{frame}
 
+\subsection{Repeating the Last Title Slide}
+\againtitle
+
 \subsection{Alternative Title Pictures}
 \maketitle[] % title page without a picture
 % examples for alternative title pictures:


### PR DESCRIPTION
I added a new macro `\againtitle` that repeats the last generated title slide with the same picture and offset. 