### PR TITLE
Remove inital extra spacing by parskip

### DIFF
--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -621,7 +621,7 @@
         coltitle=black,
         before title={\setlength{\parskip}{0ex}\vphantom{/}\let\boxnumber\thetcbcounter\csname uulm@box@#5@titleprefix\endcsname},
         after title={\let\boxnumber\thetcbcounter\csname uulm@box@#5@titlesuffix\endcsname},
-        before upper={\colorlet{uulm@text}{black}\vskip-\parskip},
+        before upper={\colorlet{uulm@text}{black}\vskip-\parskip\relax},
         fonttitle=\bfseries,
         left=#4, right=#4, top=#4, bottom=#4, bottomtitle=-.5mm,
         #1

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -621,7 +621,7 @@
         coltitle=black,
         before title={\setlength{\parskip}{0ex}\vphantom{/}\let\boxnumber\thetcbcounter\csname uulm@box@#5@titleprefix\endcsname},
         after title={\let\boxnumber\thetcbcounter\csname uulm@box@#5@titlesuffix\endcsname},
-        before upper={\colorlet{uulm@text}{black}},
+        before upper={\colorlet{uulm@text}{black}\vskip-\parskip},
         fonttitle=\bfseries,
         left=#4, right=#4, top=#4, bottom=#4, bottomtitle=-.5mm,
         #1

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -621,7 +621,7 @@
         coltitle=black,
         before title={\setlength{\parskip}{0ex}\vphantom{/}\let\boxnumber\thetcbcounter\csname uulm@box@#5@titleprefix\endcsname},
         after title={\let\boxnumber\thetcbcounter\csname uulm@box@#5@titlesuffix\endcsname},
-        before upper={\colorlet{uulm@text}{black}\vskip-\parskip\relax},
+        before upper={\colorlet{uulm@text}{black}\parskip\z@\relax},
         fonttitle=\bfseries,
         left=#4, right=#4, top=#4, bottom=#4, bottomtitle=-.5mm,
         #1


### PR DESCRIPTION
Fixes #58.

The solution is rather simple (tested with texlive23 and some older versions), we remove
the additionally introduced `\parskip` before `upper` begins. The reason for this seems indeed to be the new color mechanism in tcolorbox which introduces a parskip (normally, this would be set to `\z@`/`0pt` but Benno's modification resets it with the next marginparestore.