### PR TITLE
fix: replace fitbox in frame title for using hfill

### DIFF
--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -199,7 +199,7 @@
 
 \setbeamertemplate{frametitle}{
     \vspace{20pt}%
-    \setbox0=\hbox{\insertframetitle}%
+    \vphantom{/}\setbox0=\hbox{\insertframetitle}%
     \ifdim\wd0<\textwidth
     \insertframetitle
     \else\let\hfill\space\resizebox\linewidth!{\insertframetitle}\fi

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -199,9 +199,10 @@
 
 \setbeamertemplate{frametitle}{
     \vspace{20pt}%
-    \fitbox[maxheight=2.5ex,minheight=0pt,maxwidth=\textwidth,minwidth=0pt]{%
-        \vphantom{/}\insertframetitle{}%
-    }%
+    \setbox0=\hbox{\insertframetitle}%
+    \ifdim\wd0<\textwidth
+    \insertframetitle
+    \else\let\hfill\space\resizebox\linewidth!{\insertframetitle}\fi
 }
 \ifuniqueslidenumbersuffix
     \def\uulm@page{\insertframenumber\ifnum\insertframestartpage=\insertframeendpage\else\rlap{\color{fg!50!bg}.\insertslidenumber}\fi}


### PR DESCRIPTION
I implemented @EagleoutIce's solution to fix #30. It works fine, now `\hfill` can be used in frame titles to align parts of the title to the right.

However, the titles now seem to be a little bit smaller in general, which does not seem like a huge problem to me. What do you think @tthuem?

<img width="1662" alt="Bildschirmfoto 2023-08-22 um 10 04 44" src="https://github.com/SoftVarE-Group/SlideTemplate/assets/23581917/e763a505-8baf-4851-910f-d33912316aa9">
