### PR TITLE
feat: pic command for automatic picture links

### DIFF
--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -12,6 +12,7 @@
 \usepackage{tcolorbox} % used for color boxes (definition, example, note)
 \usepackage{ifthen}
 \usepackage{multicol} % for auto multi-column in content overview
+\usepackage{catchfile} % for automatic link on pictures
 % ---------------------------------------------
 
 
@@ -21,7 +22,7 @@
 \beamertemplatenavigationsymbolsempty % remove the default navigation symbols
 
 \AtEndPreamble{
-    \appto\Ginput@path{{../pics/logos/}{../pics/uulm/}{../pics/nature/}}
+    \setpaths{{../pics/logos/}{../pics/uulm/}{../pics/nature/}}
 }
 
 \newif\ifuniqueslidenumbersuffix
@@ -704,4 +705,24 @@
 % => \mynote and \mynotetight
 % furthermore defines the environment \begin{note}{<title>} ... \end{note}
 \uulm@DeclareBox{note}{red}
+% ---------------------------------------------
+
+% ---------------------------------------------
+% Pictures
+% ---------------------------------------------
+% GRAPHICSPATH
+\makeatletter
+\newcommand{\setpaths}[1]{
+	\appto\Ginput@path{#1} % for loading pictures
+	\def\input@path{#1} % for loading picture sources
+}
+\makeatother
+
+% adding links from text file to pictures automatically
+\newcommand\hreffile[1]{%
+	\CatchFileDef\myurl{#1}{\catcode`\#=12\catcode`\%=12\endlinechar=-1}%
+	\expandafter\href\expandafter{\myurl}}
+\newcommand{\pic}[2][]{%
+    \IfFileExists{#2.txt}{\hreffile{#2.txt}}{}{\includegraphics[#1]{#2}}
+}
 % ---------------------------------------------

--- a/demo-slides/demoSlides.tex
+++ b/demo-slides/demoSlides.tex
@@ -335,6 +335,13 @@
 	\vfill
 \end{frame}
 
+\subsection{Adding Links to Pictures Automatically}
+\begin{frame}{\insertsubsection}
+	Using the command \texttt{\textbackslash pic\{filename\}} a picture can be included. In order to automatically add a (source) link to the picture, the link simply has to be stored in a txt-file with the same filename:
+
+	\pic[width=0.5\textwidth]{jun22-clouds2}
+\end{frame}
+
 \subsection{Repeating the Last Title Slide}
 \againtitle
 

--- a/pics/nature/jun22-clouds2.txt
+++ b/pics/nature/jun22-clouds2.txt
@@ -1,0 +1,1 @@
+https://en.wikipedia.org/wiki/Cloud


### PR DESCRIPTION
I implemented the `\pic` command from the SPL slides. It can now be used to include images and automatically adding a link to them if a .txt-file with the same name as the image exists that contains the link. This therefore closes issue #63.