### PR TITLE
64 automatic dark mode for pictures

### DIFF
--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -726,4 +726,12 @@
 \newcommand{\pic}[2][]{%
     \IfFileExists{#2.txt}{\hreffile{#2.txt}}{}{\includegraphics[#1]{#2}}
 }
+\newcommand{\picDark}[2][]{\pic[#1]{#2}}
+\ifdarkmode
+	\renewcommand{\picDark}[2][]{%
+		\IfFileExists{#2-dark.png}{\pic[#1]{#2-dark.png}}{%
+		\IfFileExists{#2-dark.pdf}{\pic[#1]{#2-dark.pdf}}{%
+		\pic[#1,decodearray={1 .25 1 .25 1 .25}]{#2}}}%
+	}
+\fi
 % ---------------------------------------------

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -12,6 +12,7 @@
 \usepackage{tcolorbox} % used for color boxes (definition, example, note)
 \usepackage{ifthen}
 \usepackage{multicol} % for auto multi-column in content overview
+\usepackage{catchfile} % for automatic link on pictures
 % ---------------------------------------------
 
 
@@ -21,7 +22,7 @@
 \beamertemplatenavigationsymbolsempty % remove the default navigation symbols
 
 \AtEndPreamble{
-    \appto\Ginput@path{{../pics/logos/}{../pics/uulm/}{../pics/nature/}}
+    \setpaths{{../pics/logos/}{../pics/uulm/}{../pics/nature/}}
 }
 
 \newif\ifuniqueslidenumbersuffix
@@ -705,4 +706,24 @@
 % => \mynote and \mynotetight
 % furthermore defines the environment \begin{note}{<title>} ... \end{note}
 \uulm@DeclareBox{note}{red}
+% ---------------------------------------------
+
+% ---------------------------------------------
+% Pictures
+% ---------------------------------------------
+% GRAPHICSPATH
+\makeatletter
+\newcommand{\setpaths}[1]{
+	\appto\Ginput@path{#1} % for loading pictures
+	\def\input@path{#1} % for loading picture sources
+}
+\makeatother
+
+% adding links from text file to pictures automatically
+\newcommand\hreffile[1]{%
+	\CatchFileDef\myurl{#1}{\catcode`\#=12\catcode`\%=12\endlinechar=-1}%
+	\expandafter\href\expandafter{\myurl}}
+\newcommand{\pic}[2][]{%
+    \IfFileExists{#2.txt}{\hreffile{#2.txt}}{}{\includegraphics[#1]{#2}}
+}
 % ---------------------------------------------

--- a/demo-slides/demoSlides.tex
+++ b/demo-slides/demoSlides.tex
@@ -347,18 +347,18 @@
 	\begin{mycolumns}
 		\begin{notetight}{Normal image with \texttt{\textbackslash pic}}
 			\centering
-			\pic[width=.8\textwidth]{example-image.jpg}
+			\pic[width=.7\textwidth]{example-image.jpg}
 		\end{notetight}
 	\mynextcolumn
 		\begin{notetight}{Inverted image with \texttt{\textbackslash picDark} (in dark-mode only)}
 			\centering
-			\picDark[width=.8\textwidth]{example-image.jpg}
+			\picDark[width=.7\textwidth]{example-image.jpg}
 		\end{notetight}
 	\end{mycolumns}
 	\begin{note}{Explanation}
-		Using \texttt{\textbackslash pic} instead of \texttt{\textbackslash picDark}, images can be automatically inverted in dark-mode.
+		Using \texttt{\textbackslash picDark} instead of \texttt{\textbackslash pic}, the dark version of an image that is saved as \texttt{<image-name>-dark} automatically gets used when dark-mode is enabled.
 		
-		Therefore, white gets converted to a dark gray that matches the dark background color of the slides.
+		Images can also automatically be inverted if there is no separate dark version. Therefore, white gets converted to a dark gray that matches the dark background color of the slides.
 	\end{note}
 \end{frame}
 

--- a/demo-slides/demoSlides.tex
+++ b/demo-slides/demoSlides.tex
@@ -335,6 +335,13 @@
 	\vfill
 \end{frame}
 
+\subsection{Adding Links to Pictures Automatically}
+\begin{frame}{\insertsubsection}
+	Using the command \texttt{\textbackslash pic\{filename\}} a picture can be included. In order to automatically add a (source) link to the picture, the link simply has to be stored in a txt-file with the same filename:
+
+	\pic[width=0.5\textwidth]{jun22-clouds2}
+\end{frame}
+
 \subsection{Repeating the Last Title Slide}
 \againtitle
 

--- a/demo-slides/demoSlides.tex
+++ b/demo-slides/demoSlides.tex
@@ -342,6 +342,26 @@
 	\pic[width=0.5\textwidth]{jun22-clouds2}
 \end{frame}
 
+\subsection{Automatic Dark-Mode for Pictures}
+\begin{frame}{\insertsubsection}
+	\begin{mycolumns}
+		\begin{notetight}{Normal image with \texttt{\textbackslash pic}}
+			\centering
+			\pic[width=.8\textwidth]{example-image.jpg}
+		\end{notetight}
+	\mynextcolumn
+		\begin{notetight}{Inverted image with \texttt{\textbackslash picDark} (in dark-mode only)}
+			\centering
+			\picDark[width=.8\textwidth]{example-image.jpg}
+		\end{notetight}
+	\end{mycolumns}
+	\begin{note}{Explanation}
+		Using \texttt{\textbackslash pic} instead of \texttt{\textbackslash picDark}, images can be automatically inverted in dark-mode.
+		
+		Therefore, white gets converted to a dark gray that matches the dark background color of the slides.
+	\end{note}
+\end{frame}
+
 \subsection{Repeating the Last Title Slide}
 \againtitle
 

--- a/pics/nature/jun22-clouds2.txt
+++ b/pics/nature/jun22-clouds2.txt
@@ -1,0 +1,1 @@
+https://en.wikipedia.org/wiki/Cloud


### PR DESCRIPTION
I implemented the `\picDark` command from the SPL slides. It can be used to include images using `\pic` but automatically inverting them in dark mode (white gets inverted to a dark gray that matches the slide background). 

This therefore closes issue #64.