### PR TITLE
75 fix multi column contentoverview

### DIFF
--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -250,7 +250,7 @@
 }
 \fi
 
-\newcommand{\contentoverview}[1][1]{
+\newcommand{\contentoverview}[1][2]{ % NOTE: the default of two columns is temporary and will be changed to one in a later release
     \begin{frame}{\inserttitle}
         \linespread{.5}
         \vfill

--- a/beamerthemeuulm.sty
+++ b/beamerthemeuulm.sty
@@ -250,13 +250,18 @@
 }
 \fi
 
-\newcommand{\contentoverview}{
+\newcommand{\contentoverview}[1][1]{
     \begin{frame}{\inserttitle}
         \linespread{.5}
         \vfill
-        \begin{multicols}{2}
+        \ifthenelse{#1>1}{ % use multiple columns if more than one column is specified
+            \begin{multicols}{#1}
+                \tableofcontents
+            \end{multicols}
+        }{
             \tableofcontents
-        \end{multicols}
+        }
+
     \end{frame}
 }
 

--- a/demo-slides/demoSlides.tex
+++ b/demo-slides/demoSlides.tex
@@ -379,7 +379,7 @@
 \maketitle[may21-ulm][300]
 \maketitle[oct20-q37][350]
 
-\contentoverview % create a content overview
+\contentoverview % create a content overview (NOTE: in a future release the default column number will be set to one)
 
 %\section{Old Slide Layouts (Deprecated)}
 %

--- a/demo-slides/demoSlides.tex
+++ b/demo-slides/demoSlides.tex
@@ -379,7 +379,7 @@
 \maketitle[may21-ulm][300]
 \maketitle[oct20-q37][350]
 
-\contentoverview
+\contentoverview[2] % create a content overview with a specified number of columns (the default is 1)
 
 %\section{Old Slide Layouts (Deprecated)}
 %

--- a/demo-slides/demoSlides.tex
+++ b/demo-slides/demoSlides.tex
@@ -379,7 +379,7 @@
 \maketitle[may21-ulm][300]
 \maketitle[oct20-q37][350]
 
-\contentoverview[2] % create a content overview with a specified number of columns (the default is 1)
+\contentoverview % create a content overview
 
 %\section{Old Slide Layouts (Deprecated)}
 %


### PR DESCRIPTION
I implemented the column number parameter for the `\contentoverview` command with a temporary default of `1` in order to fix #75.